### PR TITLE
Add the new Firefox Site Compatibility site feed

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -52,3 +52,6 @@ name: IEInternals » interop
 
 [http://www.whatcouldbewrong.com/rss/?section=articles]
 name: What could be wrong?
+
+[https://www.fxsitecompat.com/en-US/index.xml]
+name: Firefox Site Compatibility


### PR DESCRIPTION
https://www.fxsitecompat.com/ is now live. From now on, Firefox Site Compatibility documents are to be posted to this new site instead of MDN.